### PR TITLE
Add google analytics dashboard to website

### DIFF
--- a/content/metrics/index.md
+++ b/content/metrics/index.md
@@ -1,2 +1,8 @@
 ### Metrics Page
 This page will display metrics for Thoth
+
+### Help Site Metrics
+
+Note: The dashboard is currently visible to users logged in with redhat.com accounts only. For access to the dashboard, please open an issue [here](https://github.com/thoth-station/help/issues/new)
+
+<iframe width="600" height="700" src="https://datastudio.google.com/embed/reporting/0d4fce38-8059-4ef2-ac2c-9f15e88ff31d/page/tWDGB" frameborder="0" style="border:0" allowfullscreen></iframe>


### PR DESCRIPTION
Currently the dashboard is only visible to Red Hat users.
related: https://github.com/open-services-group/community/issues/197